### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+package-lock.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -1,27 +1,39 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
-> A [Seneca.js](http://senecajs.org) Log Filter Module
+> A [Seneca.js][] plugin
 
+# @seneca/log-filter
 
-# seneca-log-filter
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Coverage Status][coveralls-badge]][coveralls-url]
-[![Dependency Status][david-badge]][david-url]
-[![Gitter chat][gitter-badge]][gitter-url]
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
 
-- __Sponsor:__ [nearForm][Sponsor]
+## Install
 
-## Examples
+```sh
+npm install seneca-log-filter
+```
+
+## Quick Example
 
 ```js
-var LogFilter = require('seneca-log-filter')
-var filter = LogFilter({'omit-metadata': true, level: 'info' })
-var obj = {level: 'info', foo: 'test', bar: 'test' }
-
-var filteredObj = filter(obj)
-
-// filteredObj is equal to {foo: 'test', bar: 'test' }
+require('seneca')({
+  log: { map: [{level: 'error+'}] }
+})
 ```
+
+## More Examples
+
+See [test/](test/) for usage examples.
+
+## Motivation
+
+Provides log filtering for Seneca microservices, allowing you to control which log entries are displayed.
+
+## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue][]
+- Tweet to [@senecajs][]
 
 ## API
 
@@ -34,27 +46,25 @@ var filteredObj = filter(obj)
 #### Returns
 A function which can be called on an object to filter properties out of it.
 
-## Test
-
-```sh
-npm test
-```
-
 ## Contributing
 
-This module follows the general [Senecajs org][] contribution guidelines, and encourages open participation. If you feel you can help in any way, or discover any Issues, feel free to [create an issue][issue] or [create a pull request][pr]!
+The [Senecajs org][] encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
 
-If you wish to read more on our guidelines, feel free to
+### Running tests
 
-  - Checkout the concise [contribution file][contrib]
-  - Checkout our much more indepth [contributing guidelines][contribGuide]
+```sh
+npm run test
+```
 
+## Background
 
-## License
+See [examples](https://github.com/senecajs/seneca-log-filter/tree/main/examples) for more usage.
 
-Copyright (c) 2016, David Gonzalez.
-Licensed under [MIT][].
-
+[![npm version][npm-badge]][npm-url]
+[![Build Status][travis-badge]][travis-url]
+[![Coverage Status][coveralls-badge]][coveralls-url]
+[![Dependency Status][david-badge]][david-url]
+[![Gitter chat][gitter-badge]][gitter-url]
 [MIT]: ./LICENSE
 [npm-badge]: https://badge.fury.io/js/seneca-log-filter.svg
 [npm-url]: https://badge.fury.io/js/seneca-log-filter

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "seneca-log-filter",
+  "name": "@seneca/log-filter",
   "version": "0.1.0",
   "description": "Seneca log filtering module",
   "main": "log-filter.js",


### PR DESCRIPTION
## What changed
- Renamed default branch `master` → `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`
